### PR TITLE
FEAT NAVY-103: Implement RPU resource limits for Redshift Serverless

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,14 @@
+#!/bin/zsh
+
+brewme="pre-commit tflint"
+
+for tool in $brewme
+do
+  if brew list $tool &>/dev/null; then
+    printf "$tool is already present at the system\n"
+  else
+    brew install $tool
+  fi
+done
+
+pre-commit install -f --hook-type pre-commit --hook-type pre-push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+        stages: [pre-commit]
+      - id: end-of-file-fixer
+        stages: [pre-commit]
+      - id: check-yaml
+        stages: [pre-commit]
+      - id: check-json
+        stages: [pre-commit]
+      - id: pretty-format-json
+        args:
+          - "--autofix"
+          - "--indent=4"
+          - "--no-sort-keys"
+        stages: [pre-commit]
+      - id: check-added-large-files
+        stages: [pre-commit]
+      - id: check-executables-have-shebangs
+        stages: [pre-commit]
+      - id: check-merge-conflict
+        stages: [pre-commit]
+      - id: no-commit-to-branch
+        stages: [pre-commit]
+        args: ['--branch', 'main']
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.100.0
+    hooks:
+      - id: terragrunt_fmt
+        stages: [pre-commit]
+      - id: terraform_tflint
+        stages: [pre-commit]

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ locals {
     }
     region = {
       name        = data.aws_region.this.name
-      abbr        = local.lookup.region.abbr["${data.aws_region.this.name}"]
+      abbr        = local.lookup.region.abbr[data.aws_region.this.name]
       description = data.aws_region.this.description
     }
   }

--- a/output.tf
+++ b/output.tf
@@ -50,6 +50,7 @@ output "metadata" {
         tags                 = try(aws_redshiftserverless_namespace.this.tags, null)
       }
       workgroup = try(aws_redshiftserverless_workgroup.this, null)
+      usage_limits = try(aws_redshiftserverless_usage_limit.this, [])
     }
 
     security_group = try(aws_security_group.this, null)

--- a/redshiftserverless_usage_limit.tf
+++ b/redshiftserverless_usage_limit.tf
@@ -1,0 +1,11 @@
+resource "aws_redshiftserverless_usage_limit" "this" {
+  count = length(var.usage_limits)
+
+  resource_arn    = aws_redshiftserverless_workgroup.this.arn
+  usage_type      = var.usage_limits[count.index].usage_type
+  amount          = var.usage_limits[count.index].amount
+  period          = var.usage_limits[count.index].period
+  breach_action   = var.usage_limits[count.index].breach_action
+
+  tags = local.tags
+}

--- a/redshiftserverless_workgroup.tf
+++ b/redshiftserverless_workgroup.tf
@@ -2,8 +2,8 @@ resource "aws_redshiftserverless_workgroup" "this" {
   namespace_name = aws_redshiftserverless_namespace.this.namespace_name
   workgroup_name = var.name
 
-  base_capacity = var.base_capacity
-  # config_parameter
+  base_capacity        = var.base_capacity
+  max_capacity         = var.max_capacity
   enhanced_vpc_routing = var.enhanced_vpc_routing
   publicly_accessible  = var.publicly_accessible
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -6,5 +6,13 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0, < 6.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "3.7.2"
+    }
+    null = {
+      source = "hashicorp/null"
+      version = "3.2.4"
+    }
   }
 }


### PR DESCRIPTION
This PR implements resource capacity controls and usage limits for AWS Redshift Serverless workgroups, providing better cost management and resource governance capabilities.

### ✨ New Features

**Resource Capacity Management:**
- Added max_capacity variable to set maximum RPU capacity for workgroups (4-1024 RPUs)
- Supports AWS's RPU scaling rules: 4 RPUs, 8-512 in units of 8, or 512-1024 in units of 32

**Usage Limits Configuration:**
- New usage_limits variable allowing up to 4 usage limit configurations
- Supports daily, weekly, and monthly periods
- Configurable breach actions: log, emit-metric, or deactivate
- Covers both serverless-compute and cross-region-datasharing usage types

**Infrastructure Resources:**
- New aws_redshiftserverless_usage_limit resource for RPU consumption monitoring
- Updated workgroup configuration to include max_capacity setting
- Enhanced output metadata to include usage limits information

### 🔧 Development Improvements

**Pre-commit Hooks Setup:**
- Added .pre-commit-config.yaml with comprehensive validation hooks
- Automated code formatting, JSON/YAML validation, and Terraform linting
- Branch protection preventing direct commits to main
- Environment setup script (.envrc) for automatic tool installation

**Code Quality:**
- Fixed Terraform interpolation syntax in main.tf:96
- Added missing newline at end of redshiftserverless_usage_limit.tf
- Updated provider requirements for random and null providers

### 📊 Validation & Safety

- Comprehensive input validation for all new variables
- Enforces AWS RPU capacity constraints
- Limits usage limit configurations to prevent API errors
- Type-safe variable definitions with proper defaults

This implementation provides organizations with granular control over Redshift Serverless costs while maintaining infrastructure as code best practices.