### PR TITLE
feat(NAVY-199): Add additional_iam_role_arns for namespace IAM association

### DIFF
--- a/redshiftserverless_namespace.tf
+++ b/redshiftserverless_namespace.tf
@@ -7,7 +7,7 @@ resource "aws_redshiftserverless_namespace" "this" {
   admin_username      = try(var.credentials.master.username, null)
   admin_user_password = local.master_password
 
-  iam_roles            = [aws_iam_role.this.arn]
+  iam_roles            = distinct(concat([aws_iam_role.this.arn], var.additional_iam_role_arns))
   default_iam_role_arn = aws_iam_role.this.arn
 
   log_exports = var.log_exports

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "additional_iam_role_arns" {
+  description = "Additional IAM role ARNs to associate with the Redshift Serverless namespace, beyond the default module-managed role."
+  type        = list(string)
+  default     = []
+}
+
 variable "base_capacity" {
   description = "Base Capacity"
   type        = number


### PR DESCRIPTION
## Summary

- Adds `additional_iam_role_arns` variable (list of strings, default `[]`) to allow associating extra IAM roles with the Redshift Serverless namespace beyond the default module-managed role.
- The namespace `iam_roles` attribute now merges the module's own role with any additional roles passed in.

## Context

Part of NAVY-199 (Redshift cluster → serverless migration). During migration, the serverless namespace needs the same IAM roles that were attached to the provisioned cluster:

- `FivetranServiceRole` — Fivetran data ingestion
- `VerticeRedshiftBigQueryTransferS3Writer` — BigQuery transfer UNLOAD
- `VerticeEmailInsightsRedshiftS3Writer` — Email insights UNLOAD  
- Spectrum cross-account roles

## Changes

| File | Change |
|---|---|
| `variables.tf` | New `additional_iam_role_arns` variable |
| `redshiftserverless_namespace.tf` | `iam_roles = distinct(concat([aws_iam_role.this.arn], var.additional_iam_role_arns))` |

Backward compatible — defaults to empty list, existing behavior unchanged.