### PR TITLE
FIX ASH-2094: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ehthumbs_vista.db
 .AppleDB
 .AppleDesktop
 .apdisk
+.env


### PR DESCRIPTION
Prevent committing local secrets by ignoring `.env`.

Ref: https://vertice.atlassian.net/browse/ASH-2094