### PR TITLE
FEAT NAVY-1916: Enforce require_ssl and add self-referencing SG rule for parity with cluster

### DIFF
--- a/redshiftserverless_workgroup.tf
+++ b/redshiftserverless_workgroup.tf
@@ -10,5 +10,10 @@ resource "aws_redshiftserverless_workgroup" "this" {
   security_group_ids = [aws_security_group.this.id]
   subnet_ids         = local.subnet.ids
 
+  config_parameter {
+    parameter_key   = "require_ssl"
+    parameter_value = "true"
+  }
+
   tags = local.tags
 }

--- a/security_group_rule.tf
+++ b/security_group_rule.tf
@@ -9,6 +9,16 @@ resource "aws_security_group_rule" "ingress" {
   description       = try(each.value["description"], null)
 }
 
+resource "aws_security_group_rule" "ingress_self" {
+  security_group_id        = aws_security_group.this.id
+  type                     = "ingress"
+  protocol                 = "-1"
+  from_port                = 0
+  to_port                  = 0
+  source_security_group_id = aws_security_group.this.id
+  description              = "Allow connections within the security group"
+}
+
 resource "aws_security_group_rule" "egress" {
   security_group_id = aws_security_group.this.id
   type              = "egress"


### PR DESCRIPTION
## Summary

Part of [NAVY-1916](https://vertice.atlassian.net/browse/NAVY-1916) — closing two of four Redshift Serverless config-parity gaps identified against the provisioned cluster during the cluster→serverless migration (the other two, snapshot retention and keepalive, were deliberately deferred — see ticket for the decision rationale).

- **`require_ssl` enforcement**: the cluster enforces TLS via a parameter group (`require_ssl = true`); serverless has no parameter group concept, but `aws_redshiftserverless_workgroup` supports the same setting via a `config_parameter` block (`parameter_key = "require_ssl"`). Added.
- **Self-referencing SG rule**: the cluster's security group has a self-referencing all-protocol ingress rule (`aws_vpc_security_group_ingress_rule.ingress_self`) allowing same-group components to talk to each other; the serverless SG didn't have an equivalent. Added `aws_security_group_rule.ingress_self`, matching the existing resource type/style already used in `security_group_rule.tf`.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — passes (pre-existing unrelated deprecation warnings on `data.aws_region.this.name`, not touched by this change)
- [x] Pre-commit `terraform validate with tflint` — passes
- [ ] Downstream: `tg-account-infra-bi`'s pinned `ref` needs bumping to this PR's merge commit once merged — tracked as a follow-up in NAVY-1916

[NAVY-1916]: https://vertice.atlassian.net/browse/NAVY-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ