### PR TITLE
FIX ASH-2210: Explicitly declare default Redshift Serverless workgroup config_parameters

### DIFF
--- a/redshiftserverless_workgroup.tf
+++ b/redshiftserverless_workgroup.tf
@@ -11,8 +11,48 @@ resource "aws_redshiftserverless_workgroup" "this" {
   subnet_ids         = local.subnet.ids
 
   config_parameter {
+    parameter_key   = "auto_mv"
+    parameter_value = "true"
+  }
+
+  config_parameter {
+    parameter_key   = "datestyle"
+    parameter_value = "ISO, MDY"
+  }
+
+  config_parameter {
+    parameter_key   = "enable_case_sensitive_identifier"
+    parameter_value = "false"
+  }
+
+  config_parameter {
+    parameter_key   = "enable_user_activity_logging"
+    parameter_value = "true"
+  }
+
+  config_parameter {
+    parameter_key   = "max_query_execution_time"
+    parameter_value = "14400"
+  }
+
+  config_parameter {
+    parameter_key   = "query_group"
+    parameter_value = "default"
+  }
+
+  config_parameter {
     parameter_key   = "require_ssl"
     parameter_value = "true"
+  }
+
+  config_parameter {
+    parameter_key   = "search_path"
+    parameter_value = "$user, public"
+  }
+
+  config_parameter {
+    parameter_key   = "use_fips_ssl"
+    parameter_value = "false"
   }
 
   tags = local.tags


### PR DESCRIPTION
https://vertice.atlassian.net/browse/ASH-2210

AWS provider started tracking the default `config_parameter` values in state. Without explicit declarations in the resource, Terraform plans their removal on every run. This adds all 8 AWS-default parameters to the workgroup resource so the plan stays clean.